### PR TITLE
Reuse logfmt-python logic

### DIFF
--- a/bench.rb
+++ b/bench.rb
@@ -1,0 +1,15 @@
+$:.unshift File.expand_path('../lib', __FILE__)
+
+require 'benchmark'
+require 'logfmt'
+
+N = 1_000
+line = 'foo=bar a=14 baz="hello kitty" ƒ=2h3s cool%story=bro f %^asdf'
+
+Benchmark.bm(20) do |x|
+  x.report('char-by-char') do
+    N.times do
+      Logfmt.parse(line)
+    end
+  end
+end

--- a/spec/logfmt/parser_spec.rb
+++ b/spec/logfmt/parser_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'logfmt/parser'
 
-describe Logfmt::Parser do
+describe Logfmt do
   it 'parse empty log line' do
     data = Logfmt.parse("")
     expect(data).to eq({})
@@ -55,12 +55,12 @@ describe Logfmt::Parser do
 
   it 'parse escaped quote value ' do
     data = Logfmt.parse('key="quoted \" value" r="esc\t"')
-    expect(data).to eq({"key" => 'quoted " value', "r" => "esc\t"})
+    expect(data).to eq({"key" => 'quoted \" value', "r" => "esc\\t"})
   end
 
   it 'parse mixed pairs' do
     data = Logfmt.parse('key1="quoted \" value" key2 key3=value3')
-    expect(data).to eq({"key1" => 'quoted " value', "key2" => true, "key3" => "value3"})
+    expect(data).to eq({"key1" => 'quoted \" value', "key2" => true, "key3" => "value3"})
   end
 
   it 'parse mixed characters pairs' do


### PR DESCRIPTION
Since I'm also guilty/familiar with logfmt-python logic, and it performs
relatively well, let's steal it:

```
                           user     system      total        real
char-by-char           0.050000   0.000000   0.050000 (  0.053026)
```
