### PR TITLE
Convert integers like 089 correctly

### DIFF
--- a/lib/logfmt/parser.rb
+++ b/lib/logfmt/parser.rb
@@ -15,7 +15,7 @@ module Logfmt
   
   def self.convertType(val)
     if integer?(val)
-      val = Integer(val)
+      val = Integer(val, 10)
     elsif numeric?(val)
       val = Float(val)
     end

--- a/lib/logfmt/parser.rb
+++ b/lib/logfmt/parser.rb
@@ -12,6 +12,15 @@ module Logfmt
   def self.integer?(s)
     s.match(/\A[-+]?[0-9]+\Z/)
   end
+  
+  def self.convertType(val)
+    if integer?(val)
+      val = Integer(val)
+    elsif numeric?(val)
+      val = Float(val)
+    end
+    val
+  end
 
   def self.parse(line)
     output = {}
@@ -54,33 +63,21 @@ module Logfmt
           state = GARBAGE
         end
         if i >= line.length
-          if integer?(value)
-            value = Integer(value)
-          elsif numeric?(value)
-            value = Float(value)
-          end
+          value = convertType(value)
           output[key.strip] = value || true
         end
         next
       end
       if state == IVALUE
         if !(c > ' ' && c != '"' && c != '=')
-          if integer?(value)
-            value = Integer(value)
-          elsif numeric?(value)
-            value = Float(value)
-          end
+          value = convertType(value)
           output[key.strip] = value
           state = GARBAGE
         else
           value << c
         end
         if i >= line.length
-          if integer?(value)
-            value = Integer(value)
-          elsif numeric?(value)
-            value = Float(value)
-          end
+          value = convertType(value)
           output[key.strip] = value
         end
         next

--- a/spec/logfmt/parser_spec.rb
+++ b/spec/logfmt/parser_spec.rb
@@ -86,6 +86,12 @@ describe Logfmt do
     expect(data['key']).to eq(234)
     expect(data['key'].class).to eq(Fixnum)
   end
+  
+  it 'parse integer prefixed with zero correctly' do
+    data = Logfmt.parse('key=0789')
+    expect(data).to eq('key' => 789)
+    expect(data['key'].class).to eq(Fixnum)
+  end
 
   it 'parse negative integer as integer type' do
     data = Logfmt.parse('key=-3428')


### PR DESCRIPTION
Expect all integer values to be in base 10. This way the conversion doesn't try to interpret e.g. 089 as an octal number (which it obviously isn't).

The first commit in this PR just refactors a repeated code snippet into a helper method.