### PR TITLE
Move parser to own module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## \[Unreleased\]
 
+## [0.0.10] 2022-04-30
 ### Changed
   - Autoload the `Logfmt::Parser` when it's used, in preparation for the coming `Logfmt::Logger` and friends.
     Alternatively you can eager-load it into memory: `require "logfmt/parser"`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+
+### Changed
+  - Autoload the `Logfmt::Parser` when it's used, in preparation for the coming `Logfmt::Logger` and friends.
+    Alternatively you can eager-load it into memory: `require "logfmt/parser"`.
+
+### Added
+  - This CHANGELOG file.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # Logfmt
 
-Parse log lines on the logfmt style:
+Parse log lines in the logfmt style:
 
-    >> require "logfmt"
-    >> Logfmt.parse('foo=bar a=14 baz="hello kitty" cool%story=bro f %^asdf')
-    => {"foo"=>"bar", "a"=>14, "baz"=>"hello kitty", "cool%story"=>"bro", "f"=>true, "%^asdf"=>true}
+```ruby
+require "logfmt/parser"
+
+Logfmt::Parser.parse('foo=bar a=14 baz="hello kitty" cool%story=bro f %^asdf')
+  #=> {"foo"=>"bar", "a"=>14, "baz"=>"hello kitty", "cool%story"=>"bro", "f"=>true, "%^asdf"=>true}
+```

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "logfmt"
+
+require "pry"
+Pry.start

--- a/lib/logfmt.rb
+++ b/lib/logfmt.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 
 require "logfmt/version"
-require "logfmt/parser"
+
+module Logfmt
+  autoload(:Parser, "logfmt/parser")
+
+  def self.parse(line)
+    const_get(:Parser).parse(line)
+  end
+end

--- a/lib/logfmt/parser.rb
+++ b/lib/logfmt/parser.rb
@@ -1,114 +1,118 @@
 # frozen_string_literal: true
 
+require_relative "../logfmt"
+
 module Logfmt
-  GARBAGE = 0
-  KEY = 1
-  EQUAL = 2
-  IVALUE = 3
-  QVALUE = 4
+  module Parser
+    GARBAGE = 0
+    KEY = 1
+    EQUAL = 2
+    IVALUE = 3
+    QVALUE = 4
 
-  def self.numeric?(s)
-    s.is_a?(Numeric) || s.to_s.match(/\A[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?\Z/)
-  end
-
-  def self.integer?(s)
-    s.is_a?(Integer) || s.to_s.match(/\A[-+]?[0-9]+\Z/)
-  end
-
-  def self.parse(line)
-    output = {}
-    key, value = +"", +""
-    escaped = false
-    state = GARBAGE
-    i = 0
-    line.each_char do |c|
-      i += 1
-      if state == GARBAGE
-        if c > " " && c != '"' && c != "="
-          key = c
-          state = KEY
-        end
-        next
-      end
-      if state == KEY
-        if c > " " && c != '"' && c != "="
-          state = KEY
-          key << c
-        elsif c == "="
-          output[key.strip] = true
-          state = EQUAL
-        else
-          output[key.strip] = true
-          state = GARBAGE
-        end
-        output[key.strip] = true if i >= line.length
-        next
-      end
-      if state == EQUAL
-        if c > " " && c != '"' && c != "="
-          value = c
-          state = IVALUE
-        elsif c == '"'
-          value = +""
-          escaped = false
-          state = QVALUE
-        else
-          state = GARBAGE
-        end
-        if i >= line.length
-          if integer?(value)
-            value = value.to_i
-          elsif numeric?(value)
-            fvalue = value.to_f
-            value = fvalue if fvalue.finite?
-          end
-          output[key.strip] = value || true
-        end
-        next
-      end
-      if state == IVALUE
-        if !(c > " " && c != '"')
-          if integer?(value)
-            value = value.to_i
-          elsif numeric?(value)
-            fvalue = value.to_f
-            value = fvalue if fvalue.finite?
-          end
-          output[key.strip] = value
-          state = GARBAGE
-        else
-          value << c
-        end
-        if i >= line.length
-          if integer?(value)
-            value = value.to_i
-          elsif numeric?(value)
-            fvalue = value.to_f
-            value = fvalue if fvalue.finite?
-          end
-          output[key.strip] = value
-        end
-        next
-      end
-      if state == QVALUE
-        if c == "\\"
-          escaped = true
-          value << "\\"
-        elsif c == '"'
-          if escaped
-            escaped = false
-            value.chop! << c
-            next
-          end
-          output[key.strip] = value
-          state = GARBAGE
-        else
-          escaped = false
-          value << c
-        end
-        next
-      end
+    def self.numeric?(s)
+      s.is_a?(Numeric) || s.to_s.match?(/\A[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?\Z/)
     end
-    output
+
+    def self.integer?(s)
+      s.is_a?(Integer) || s.to_s.match?(/\A[-+]?[0-9]+\Z/)
+    end
+
+    def self.parse(line)
+      output = {}
+      key, value = +"", +""
+      escaped = false
+      state = GARBAGE
+      i = 0
+      line.each_char do |c|
+        i += 1
+        if state == GARBAGE
+          if c > " " && c != '"' && c != "="
+            key = c
+            state = KEY
+          end
+          next
+        end
+        if state == KEY
+          if c > " " && c != '"' && c != "="
+            state = KEY
+            key << c
+          elsif c == "="
+            output[key.strip] = true
+            state = EQUAL
+          else
+            output[key.strip] = true
+            state = GARBAGE
+          end
+          output[key.strip] = true if i >= line.length
+          next
+        end
+        if state == EQUAL
+          if c > " " && c != '"' && c != "="
+            value = c
+            state = IVALUE
+          elsif c == '"'
+            value = +""
+            escaped = false
+            state = QVALUE
+          else
+            state = GARBAGE
+          end
+          if i >= line.length
+            if integer?(value)
+              value = value.to_i
+            elsif numeric?(value)
+              fvalue = value.to_f
+              value = fvalue if fvalue.finite?
+            end
+            output[key.strip] = value || true
+          end
+          next
+        end
+        if state == IVALUE
+          if !(c > " " && c != '"')
+            if integer?(value)
+              value = value.to_i
+            elsif numeric?(value)
+              fvalue = value.to_f
+              value = fvalue if fvalue.finite?
+            end
+            output[key.strip] = value
+            state = GARBAGE
+          else
+            value << c
+          end
+          if i >= line.length
+            if integer?(value)
+              value = value.to_i
+            elsif numeric?(value)
+              fvalue = value.to_f
+              value = fvalue if fvalue.finite?
+            end
+            output[key.strip] = value
+          end
+          next
+        end
+        if state == QVALUE
+          if c == "\\"
+            escaped = true
+            value << "\\"
+          elsif c == '"'
+            if escaped
+              escaped = false
+              value.chop! << c
+              next
+            end
+            output[key.strip] = value
+            state = GARBAGE
+          else
+            escaped = false
+            value << c
+          end
+          next
+        end
+      end
+      output
+    end
   end
 end

--- a/lib/logfmt/version.rb
+++ b/lib/logfmt/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Logfmt
-  VERSION = "0.0.9"
+  VERSION = "0.0.10"
 end

--- a/logfmt.gemspec
+++ b/logfmt.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_development_dependency "pry-byebug", "~> 3.9"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/spec/logfmt/parser_spec.rb
+++ b/spec/logfmt/parser_spec.rb
@@ -1,148 +1,148 @@
-require "logfmt/parser"
+RSpec.describe Logfmt::Parser do
+  subject(:parser) { described_class }
 
-RSpec.describe Logfmt do
-  it "parse empty log line" do
-    data = Logfmt.parse("")
+  it "parses empty log line" do
+    data = parser.parse("")
     expect(data).to eq({})
   end
 
-  it "parse whitespace only log line" do
-    data = Logfmt.parse("\t")
+  it "parses whitespace only log line" do
+    data = parser.parse("\t")
     expect(data).to eq({})
   end
 
-  it "parse key without value" do
-    data = Logfmt.parse("key")
+  it "parses key without value" do
+    data = parser.parse("key")
     expect(data).to eq("key" => true)
   end
 
-  it "parse key without value and whitespace" do
-    data = Logfmt.parse("  key  ")
+  it "parses key without value and whitespace" do
+    data = parser.parse("  key  ")
     expect(data).to eq("key" => true)
   end
 
-  it "parse multiple single keys" do
-    data = Logfmt.parse("key1 key2")
+  it "parses multiple single keys" do
+    data = parser.parse("key1 key2")
     expect(data).to eq("key1" => true, "key2" => true)
   end
 
-  it "parse unquoted value" do
-    data = Logfmt.parse("key=value")
+  it "parses unquoted value" do
+    data = parser.parse("key=value")
     expect(data).to eq("key" => "value")
   end
 
-  it "parse pairs" do
-    data = Logfmt.parse("key1=value1 key2=value2")
+  it "parses pairs" do
+    data = parser.parse("key1=value1 key2=value2")
     expect(data).to eq("key1" => "value1", "key2" => "value2")
   end
 
-  it "parse mixed single/non-single pairs" do
-    data = Logfmt.parse("key1=value1 key2")
+  it "parses mixed single/non-single pairs" do
+    data = parser.parse("key1=value1 key2")
     expect(data).to eq("key1" => "value1", "key2" => true)
   end
 
-  it "parse mixed pairs whatever the order" do
-    data = Logfmt.parse("key1 key2=value2")
+  it "parses mixed pairs whatever the order" do
+    data = parser.parse("key1 key2=value2")
     expect(data).to eq("key1" => true, "key2" => "value2")
   end
 
-  it "parse quoted value" do
-    data = Logfmt.parse('key="quoted value"')
+  it "parses quoted value" do
+    data = parser.parse('key="quoted value"')
     expect(data).to eq("key" => "quoted value")
   end
 
-  it "parse escaped quote value " do
-    data = Logfmt.parse('key="quoted \" value" r="esc\t"')
+  it "parses escaped quote value " do
+    data = parser.parse('key="quoted \" value" r="esc\t"')
     expect(data).to eq("key" => 'quoted " value', "r" => 'esc\t')
   end
 
-  it "parse mixed pairs" do
-    data = Logfmt.parse('key1="quoted \" value" key2 key3=value3')
+  it "parses mixed pairs" do
+    data = parser.parse('key1="quoted \" value" key2 key3=value3')
     expect(data).to eq("key1" => 'quoted " value', "key2" => true, "key3" => "value3")
   end
 
-  it "parse mixed characters pairs" do
-    data = Logfmt.parse('foo=bar a=14 baz="hello kitty" ƒ=2h3s cool%story=bro f %^asdf')
+  it "parses mixed characters pairs" do
+    data = parser.parse('foo=bar a=14 baz="hello kitty" ƒ=2h3s cool%story=bro f %^asdf')
     expect(data).to eq("foo" => "bar", "a" => 14, "baz" => "hello kitty",
       "ƒ" => "2h3s", "cool%story" => "bro", "f" => true, "%^asdf" => true)
   end
 
-  it "parse pair with empty quote" do
-    data = Logfmt.parse('key=""')
+  it "parses pair with empty quote" do
+    data = parser.parse('key=""')
     expect(data).to eq("key" => "")
   end
 
   # Currently, the value comes back as "true", which could mess up stats
   # Really, only "true" should come back as "true"
   # it 'parse 1 as integer type' do
-  #   data = Logfmt.parse('key=1')
+  #   data = parser.parse('key=1')
   #   expect(data['key'].class).to eq(Fixnum)
   # end
 
-  it "parse positive integer as integer type" do
-    data = Logfmt.parse("key=234")
+  it "parses positive integer as integer type" do
+    data = parser.parse("key=234")
     expect(data["key"]).to eq(234)
     expect(data["key"].class).to eq(Integer)
   end
 
-  it "parse negative integer as integer type" do
-    data = Logfmt.parse("key=-3428")
+  it "parses negative integer as integer type" do
+    data = parser.parse("key=-3428")
     expect(data["key"]).to eq(-3428)
     expect(data["key"].class).to eq(Integer)
   end
 
-  it "parse positive float as float type" do
-    data = Logfmt.parse("key=3.342")
+  it "parses positive float as float type" do
+    data = parser.parse("key=3.342")
     expect(data["key"]).to eq(3.342)
     expect(data["key"].class).to eq(Float)
   end
 
-  it "parse negative float as float type" do
-    data = Logfmt.parse("key=-0.9934")
+  it "parses negative float as float type" do
+    data = parser.parse("key=-0.9934")
     expect(data["key"]).to eq(-0.9934)
     expect(data["key"].class).to eq(Float)
   end
 
-  it "parse exponential float as float type" do
-    data = Logfmt.parse("key=2.342342342342344e+18")
+  it "parses exponential float as float type" do
+    data = parser.parse("key=2.342342342342344e+18")
     expect(data["key"]).to eq(2.342342342342344e+18)
     expect(data["key"].class).to eq(Float)
   end
 
-  it "parse long digit string with embedded e as string" do
-    data = Logfmt.parse("key=2342342342342344e1818")
+  it "parses long digit string with embedded e as string" do
+    data = parser.parse("key=2342342342342344e1818")
     expect(data["key"].class).to eq(String)
   end
 
-  it "parse quoted integer as string type" do
-    data = Logfmt.parse('key="234"')
+  it "parses quoted integer as string type" do
+    data = parser.parse('key="234"')
     expect(data["key"].class).to eq(String)
   end
 
-  it "parse quoted float as string type" do
-    data = Logfmt.parse('key="3.14"')
+  it "parses quoted float as string type" do
+    data = parser.parse('key="3.14"')
     expect(data["key"].class).to eq(String)
   end
 
-  it "parse IP address as string type" do
-    data = Logfmt.parse("key=10.10.10.1")
+  it "parses IP address as string type" do
+    data = parser.parse("key=10.10.10.1")
     expect(data["key"].class).to eq(String)
   end
 
-  it "parse last as integer type" do
-    data = Logfmt.parse("key1=4 key2=9")
+  it "parses last as integer type" do
+    data = parser.parse("key1=4 key2=9")
     expect(data["key1"]).to eq(4)
     expect(data["key2"]).to eq(9)
   end
 
-  it "parse string containing quotes" do
-    data = Logfmt.parse('key1="{\"msg\": \"hello\tworld\"}"')
+  it "parses string containing quotes" do
+    data = parser.parse('key1="{\"msg\": \"hello\tworld\"}"')
     expect(data["key1"]).to eq('{"msg": "hello\tworld"}')
   end
 
-  it "parse value containing equal sign" do
+  it "parses value containing equal sign" do
     query = "position=44.80450799126121%2C33.58320759981871&uid=1"
-    data = Logfmt.parse("method=GET query=#{query} status=200")
+    data = parser.parse("method=GET query=#{query} status=200")
     expect(data).to eq(
       "method" => "GET",
       "query" => query,
@@ -151,7 +151,7 @@ RSpec.describe Logfmt do
   end
 
   it "parses integers correctly" do
-    data = Logfmt.parse("key=111 ")
+    data = parser.parse("key=111 ")
     expect(data["key"]).to eq(111)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# require File.expand_path("../lib/dumb_delegator", File.dirname(__FILE__))
+require "logfmt"
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
@@ -16,6 +19,10 @@ RSpec.configure do |config|
 
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
+  end
+
+  config.define_derived_metadata do |meta|
+    meta[:aggregate_failures] = true
   end
 
   config.order = "random"


### PR DESCRIPTION
Then we can autoload it only if used. This makes room for the coming `Logfmt::Logger`-ish stuff; one use case is the parser to read log lines, and the other is the Logger to write them. We don't want to force one use case to load the other into memory.