### PR TITLE
Fix backslash quoting

### DIFF
--- a/lib/logfmt/parser.rb
+++ b/lib/logfmt/parser.rb
@@ -94,19 +94,19 @@ module Logfmt
           next
         end
         if state == QVALUE
-          if c == "\\"
-            escaped = true
-            value << "\\"
-          elsif c == '"'
-            if escaped
-              escaped = false
-              value.chop! << c
-              next
+          if escaped
+            if c == "\\" or c == '"'
+              value << c
+            else
+              value << "\\" + c
             end
-            output[key.strip] = value
+            escaped = false
+          elsif c == "\\"
+            escaped = true
+          elsif c == '"'
+            output[key] = value
             state = GARBAGE
           else
-            escaped = false
             value << c
           end
           next

--- a/spec/logfmt/parser_spec.rb
+++ b/spec/logfmt/parser_spec.rb
@@ -154,4 +154,14 @@ RSpec.describe Logfmt::Parser do
     data = parser.parse("key=111 ")
     expect(data["key"]).to eq(111)
   end
+
+  it "parses quoted backslash" do
+    data = parser.parse('key="\\\\"')
+    expect(data["key"]).to eq('\\')
+  end
+
+  it "parses nested quoted quote" do
+    data = parser.parse('key="{\"msg\": \"say \\\\\"hi\\\\\"\"}"')
+    expect(data["key"]).to eq('{"msg": "say \"hi\""}')
+  end
 end


### PR DESCRIPTION
This PR fixes handling of quoted backslashes.

Example logfmt line that causes trouble:

```
key="{\"msg\": \"say \\\"hi\\\"}"
```
Result of `Logfmt.parse`:
```
{"msg": "say \\"hi\\""}
```
But it should be:
```
{"msg": "say \"hi\""}
```